### PR TITLE
Export library classes in JAR file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,14 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>2.5</version>
+                    <configuration>
+                        <attachClasses>true</attachClasses>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
                     <version>2.8</version>
                 </plugin>


### PR DESCRIPTION
Before moving the project to Maven there was the possibility to distribute a JAR file for using the cache implementation and driver interfaces in OAI provider implementations. With exporting the classes to a JAR on packaging, this option is restored.

Btw: What about new releases?
